### PR TITLE
Add chat mode support

### DIFF
--- a/components/chat-panel.tsx
+++ b/components/chat-panel.tsx
@@ -335,14 +335,14 @@ useEffect(() => {
               </div>
           </div>
         </div>
-        {(!mode || mode === 'default') && (
-            <div className="mt-2">
-              <ChatModeSelector
-                initial="default"
-                onChange={(id) => router.push(`/chat/new?mode=${id}`)}
-              />
-            </div>
-          )}
+        {messages.length === 0 && (!mode || mode === 'default') && (
+          <div className="mt-2">
+            <ChatModeSelector
+              initial="default"
+              onChange={(id) => router.push(`/chat/new?mode=${id}`)}
+            />
+          </div>
+        )}
         <div className="relative">
           {messages.length === 0 && (
             <div className="absolute top-0 left-0 right-0 min-h-[120px] max-h-[200px] overflow-hidden">

--- a/lib/agents/get-agent.ts
+++ b/lib/agents/get-agent.ts
@@ -1,0 +1,23 @@
+import { createListenerStreamResponse } from '@/lib/streaming/create-listener-stream'
+import { createManualToolStreamResponse } from '@/lib/streaming/create-manual-tool-stream'
+import { createToolCallingStreamResponse } from '@/lib/streaming/create-tool-calling-stream'
+import type { BaseStreamConfig } from '@/lib/streaming/types'
+
+export type AgentHandler = (config: BaseStreamConfig) => Response | Promise<Response>
+
+const handlers: Record<string, AgentHandler> = {
+  listener: createListenerStreamResponse
+}
+
+export function getAgentForMode(mode: string): AgentHandler {
+  if (handlers[mode]) {
+    return handlers[mode]
+  }
+
+  return (config: BaseStreamConfig) => {
+    const supportsToolCalling = config.model.toolCallType === 'native'
+    return supportsToolCalling
+      ? createToolCallingStreamResponse(config)
+      : createManualToolStreamResponse(config)
+  }
+}

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -63,6 +63,7 @@ export interface Chat extends Record<string, any> {
   createdAt: Date
   userId: string
   path: string
+  mode?: string
   messages: ExtendedCoreMessage[] // Note: Changed from AIMessage to ExtendedCoreMessage
   sharePath?: string
 }


### PR DESCRIPTION
## Summary
- add central `getAgentForMode` helper
- dynamically call agents in chat API route
- show mode selector only before chat starts
- track chosen mode in `Chat` type

## Testing
- `npm run lint` *(fails: next not found)*
- `npx tsc -p tsconfig.json` *(fails: missing type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_684e4f842bd48329ab283e7e989f0ccd