### PR TITLE
Add chat mode support

### DIFF
--- a/app/chat/new/page.tsx
+++ b/app/chat/new/page.tsx
@@ -16,11 +16,12 @@ export default async function NewChatPage(props: {
   await redis.hmset(`chat:${chatId}`, {
     userId,
     mode,
-    createdAt: Date.now()
+    createdAt: Date.now(),
+    path: `/search/${chatId}`
   })
 
   // Add to user's chat list
-  await redis.zadd(`user:v2:chat:${userId}`, Date.now(), chatId)
+  await redis.zadd(`user:v2:chat:${userId}`, Date.now(), `chat:${chatId}`)
 
   // Redirect to chat page
   redirect(`/search/${chatId}`)

--- a/app/chat/new/page.tsx
+++ b/app/chat/new/page.tsx
@@ -14,6 +14,7 @@ export default async function NewChatPage(props: {
 
   // Save chat metadata
   await redis.hmset(`chat:${chatId}`, {
+    id: chatId,
     userId,
     mode,
     createdAt: Date.now(),

--- a/components/chat-panel.tsx
+++ b/components/chat-panel.tsx
@@ -335,14 +335,14 @@ useEffect(() => {
               </div>
           </div>
         </div>
-        {(!mode || mode === 'default') && (
-            <div className="mt-2">
-              <ChatModeSelector
-                initial="default"
-                onChange={(id) => router.push(`/chat/new?mode=${id}`)}
-              />
-            </div>
-          )}
+        {messages.length === 0 && (!mode || mode === 'default') && (
+          <div className="mt-2">
+            <ChatModeSelector
+              initial="default"
+              onChange={(id) => router.push(`/chat/new?mode=${id}`)}
+            />
+          </div>
+        )}
         <div className="relative">
           {messages.length === 0 && (
             <div className="absolute top-0 left-0 right-0 min-h-[120px] max-h-[200px] overflow-hidden">

--- a/components/chat/chat-mode-selector.tsx
+++ b/components/chat/chat-mode-selector.tsx
@@ -50,13 +50,18 @@ export default function ChatModeSelector({
           {chatModes.map(mode => (
             <button
               key={mode.id}
-              onClick={() => {
+              onClick={mode.id === 'default' ? undefined : () => {
                 setSelectedId(mode.id)
                 onChange(mode.id)
                 setOpen(false)
-                router.push(`/chat/new?mode=${mode.id}`) // ✅ Better than window.location.href
+                router.push(`/chat/new?mode=${mode.id}`)
               }}
-              className="w-full text-left px-3 py-2 text-sm hover:bg-gray-700"
+              className={
+                mode.id === 'default'
+                  ? 'w-full text-left px-3 py-2 text-sm cursor-not-allowed text-gray-500'
+                  : 'w-full text-left px-3 py-2 text-sm hover:bg-gray-700'
+              }
+              disabled={mode.id === 'default'}
             >
               {mode.icon && <span className="mr-2">{mode.icon}</span>}
               {mode.name}

--- a/lib/agents/get-agent.ts
+++ b/lib/agents/get-agent.ts
@@ -1,0 +1,23 @@
+import { createListenerStreamResponse } from '@/lib/streaming/create-listener-stream'
+import { createManualToolStreamResponse } from '@/lib/streaming/create-manual-tool-stream'
+import { createToolCallingStreamResponse } from '@/lib/streaming/create-tool-calling-stream'
+import type { BaseStreamConfig } from '@/lib/streaming/types'
+
+export type AgentHandler = (config: BaseStreamConfig) => Response | Promise<Response>
+
+const handlers: Record<string, AgentHandler> = {
+  listener: createListenerStreamResponse
+}
+
+export function getAgentForMode(mode: string): AgentHandler {
+  if (handlers[mode]) {
+    return handlers[mode]
+  }
+
+  return (config: BaseStreamConfig) => {
+    const supportsToolCalling = config.model.toolCallType === 'native'
+    return supportsToolCalling
+      ? createToolCallingStreamResponse(config)
+      : createManualToolStreamResponse(config)
+  }
+}

--- a/lib/streaming/handle-stream-finish.ts
+++ b/lib/streaming/handle-stream-finish.ts
@@ -91,6 +91,10 @@ export async function handleStreamFinish({
       id: chatId
     }
 
+    if (!savedChat.id) {
+      savedChat.id = chatId
+    }
+
     // Save chat with complete response and related questions
     await saveChat(
       {

--- a/lib/streaming/handle-stream-finish.ts
+++ b/lib/streaming/handle-stream-finish.ts
@@ -86,7 +86,7 @@ export async function handleStreamFinish({
       createdAt: new Date(),
       userId: userId,
       mode: mode || 'default',
-      path: `/chat/${mode || 'default'}/${chatId}`, // 🛠 fixed path
+      path: `/search/${chatId}`,
       title: safeTitle,
       id: chatId
     }
@@ -97,7 +97,7 @@ export async function handleStreamFinish({
         ...savedChat,
         messages: generatedMessages,
         mode: mode || savedChat.mode || 'default',
-        path: `/chat/${mode || savedChat.mode || 'default'}/${chatId}`
+        path: `/search/${chatId}`
       },
       userId
     ).catch(error => {

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -63,6 +63,7 @@ export interface Chat extends Record<string, any> {
   createdAt: Date
   userId: string
   path: string
+  mode?: string
   messages: ExtendedCoreMessage[] // Note: Changed from AIMessage to ExtendedCoreMessage
   sharePath?: string
 }


### PR DESCRIPTION
## Summary
- add central `getAgentForMode` helper
- dynamically call agents in chat API route
- show mode selector only before chat starts
- track chosen mode in `Chat` type
- save chat mode correctly and disable the default item in the selector
- fix chat list key when creating new chats

## Testing
- `npm run lint` *(fails: next not found)*
- `npx tsc -p tsconfig.json` *(fails: missing type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_684e4f842bd48329ab283e7e989f0ccd